### PR TITLE
Rename "Path" to "Locator" and clarify what properties mean what.

### DIFF
--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -3,17 +3,9 @@ var acorn = require("acorn");
 var walk = require("acorn/dist/walk");
 var path = require("path");
 var fs = require("fs");
+var Locator = require("./locator");
 
 var mochaSettings = require("./settings");
-
-var Path = function (path, filename) {
-  this.path = path;
-  this.filename = filename;
-};
-
-Path.prototype.toString = function () {
-  return this.path;
-};
 
 module.exports = function () {
   var sourceFolders = mochaSettings.mochaTestFolders;
@@ -54,7 +46,7 @@ module.exports = function () {
     walk.findNodeAt(root, null, null, function (nodeType, node) {
       if (nodeType === "CallExpression" && node.callee.name === "it") {
         var name = node.arguments[0].value;
-        children.push(new Path(name, filename));
+        children.push(new Locator(name, filename));
       }
     });
     return children;

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -6,3 +6,5 @@ var Locator = function (name, filename) {
 Locator.prototype.toString = function () {
   return this.name;
 };
+
+module.exports = Locator;

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -1,0 +1,8 @@
+var Locator = function (name, filename) {
+  this.name = name;
+  this.filename = filename;
+};
+
+Locator.prototype.toString = function () {
+  return this.name;
+};

--- a/lib/tag_filter.js
+++ b/lib/tag_filter.js
@@ -30,7 +30,7 @@ var isMatched = function(tags, f) {
   }
 
   walk.findNodeAt(root, null, null, function (nodeType, node) {
-    if (!pass && nodeType === "CallExpression" && node.callee.name === "it" && node.arguments[0].value === f.path) {
+    if (!pass && nodeType === "CallExpression" && node.callee.name === "it" && node.arguments[0].value === f.name) {
       var name = node.arguments[0].value;
       var matchedTags = 0;
       var nodeTags = name.split(" ");

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -94,7 +94,7 @@ RowdyMochaTestRun.prototype.getEnvironment = function (env) {
 };
 
 RowdyMochaTestRun.prototype.getArguments = function () {
-  var grepString = this.path.toString();
+  var grepString = this.locator.name;
 
   var escapees = "\\^$[]+*.\"";
   escapees.split("").forEach(function (ch) {
@@ -104,7 +104,7 @@ RowdyMochaTestRun.prototype.getArguments = function () {
   var args = [
     "--mocking_port=" + this.mockingPort,
     "--worker=1",
-    this.path.filename
+    this.locator.filename
   ];
 
   if (mochaSettings.mochaOpts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-mocha-plugin",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Magellan plugin to provide Mocha support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Related to https://github.com/TestArmada/magellan/issues/99
- Rename `Path` class to `Locator` and move to `locator.js`
- Rename locator's `path` property to `name`, since in mocha this isn't a path but a `it()` string.
- Rename TestRun's `path` property to `locator`. Magellan will use `locator` in the future.
