### PR TITLE
Added support to pass --host argument

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,10 +1,12 @@
 var settings = {
   mochaOpts: undefined, // --mocha_opts opts_file
   mochaTestFolders: undefined, // --mocha_tests location (or array in magellan.json)
-
+  host: undefined,  // --host e.g. test.mydomain.com
+  
   initialize: function (argv) {
     settings.mochaOpts = argv.mocha_opts;
     settings.mochaTestFolders = argv.mocha_tests;
+    settings.host = argv.host;
   }
 };
 

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -108,6 +108,10 @@ RowdyMochaTestRun.prototype.getArguments = function () {
     grepString
   ];
 
+  if (mochaSettings.host){
+    args.push("--host", mochaSettings.host);
+  }
+  
   if (mochaSettings.mochaOpts) {
     args.push("--opts", mochaSettings.mochaOpts);
   }


### PR DESCRIPTION
Having the ability to supply an optional host domain argument from the command line and get it passed through to our custom test code that loads data based on host is needed when multiple test runs are batched.  For example:

$ magellan --host=testus.acme.com
$ magellan --host=testuk.acme.com
$ magellan --host=testca.acme.com
