### PR TITLE
Update to node's own spawnSync and require node v4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "node"
-  - "iojs"
-  - "0.12"
-  - "0.10"
+  - v7
+  - v6
+  - v5
+  - v4
 sudo: false

--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var fs = require('fs');
 var path = require("path");
-var spawnSync = require('spawn-sync');
+var spawnSync = require("child_process").spawnSync;
 var Locator = require("./locator");
 var mochaSettings = require("./settings");
 var reporter = path.resolve(__dirname, 'test_capture.js');

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://github.com/TestArmada/magellan-mocha-plugin#readme",
   "dependencies": {
-    "lodash": "^4.17.2",
-    "spawn-sync": "^1.0.15"
+    "lodash": "^4.17.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
The `spawn-sync` module has started to cause trouble for us. This is a module that fills in `spawnSync` support for older versions of node (i.e. pre-`0.11`). We've started updating the entire TestArmada suite to `4` and up, and this PR updates us to node's own `spawnSync`, and should alleviate the testing issues we're having with Travis on other dependent modules.

/cc @jherr @geekdave @archlichking 