### PR TITLE
Fix temp directory, failure on os.tmpdir() warnings in newer nodes

### DIFF
--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -9,7 +9,7 @@ var reporter = path.resolve(__dirname, 'test_capture.js');
 module.exports = function(settings) {
   var OUTPUT_PATH = path.resolve(settings.tempDir, 'get_mocha_tests.json');
 
-  if (!fs.existsSync(settings.tempDir)){
+  if (!fs.existsSync(settings.tempDir)) {
     fs.mkdirSync(settings.tempDir);
   }
 

--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -8,6 +8,11 @@ var reporter = path.resolve(__dirname, 'test_capture.js');
 
 module.exports = function(settings) {
   var OUTPUT_PATH = path.resolve(settings.tempDir, 'get_mocha_tests.json');
+
+  if (!fs.existsSync(settings.tempDir)){
+    fs.mkdirSync(settings.tempDir);
+  }
+
   var cmd = './node_modules/.bin/mocha';
   var args = ['--reporter', reporter];
 
@@ -19,7 +24,7 @@ module.exports = function(settings) {
   var env = _.extend({}, process.env, {MOCHA_CAPTURE_PATH: OUTPUT_PATH});
   var capture = spawnSync(cmd, args, {env: env});
 
-  if (capture.status !== 0 || capture.stderr.toString()) {
+  if (capture.status !== 0) {
     console.error('Could not capture mocha tests. To debug, run the following command:\nMOCHA_CAPTURE_PATH=%s %s %s', OUTPUT_PATH, cmd, args.join(' '));
     process.exit(1);
   }


### PR DESCRIPTION
This PR fixes two bugs:

  - A bug where if `./temp` doesn't exist, the plugin doesn't create it, but tells mocha to write there.
  - A bug where if newer versions of node are used, mocha outputs the **warning** (but not **error**) text `(node:10530) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.` to stderr, causing our plugin code to think there's an error (even though status is `0`).

/cc @jherr 