### PR TITLE
Add suite-level filter and runtime mocha args

### DIFF
--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -19,7 +19,7 @@ module.exports = function (settings) {
   var cmd = "./node_modules/.bin/mocha";
   var args = [];
 
-  if ( mochaSettings.suiteTag !== undefined ) {
+  if (mochaSettings.suiteTag !== undefined) {
     reporter = path.resolve(__dirname, "suite_capture.js");
     args.push("--reporter-options", "tag=" + mochaSettings.suiteTag);
   }

--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -8,7 +8,6 @@ var path = require("path");
 var spawnSync = require("child_process").spawnSync;
 var Locator = require("./locator");
 var mochaSettings = require("./settings");
-var reporter = path.resolve(__dirname, "test_capture.js");
 var logger = require("testarmada-logger");
 
 module.exports = function (settings) {
@@ -21,6 +20,7 @@ module.exports = function (settings) {
 
   var cmd = "./node_modules/.bin/mocha";
   var args = [];
+  var reporter = path.resolve(__dirname, "test_capture.js");
 
   if (mochaSettings.suiteTag !== undefined) {
     reporter = path.resolve(__dirname, "suite_capture.js");

--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -17,7 +17,14 @@ module.exports = function (settings) {
   }
 
   var cmd = "./node_modules/.bin/mocha";
-  var args = ["--reporter", reporter];
+  var args = [];
+
+  if ( mochaSettings.suiteTag !== undefined ) {
+    reporter = path.resolve(__dirname, "suite_capture.js");
+    args.push("--reporter-options", "tag=" + mochaSettings.suiteTag);
+  }
+
+  args.push("--reporter", reporter);
 
   /* istanbul ignore else */
   if (mochaSettings.mochaOpts) {

--- a/lib/get_tests.js
+++ b/lib/get_tests.js
@@ -22,7 +22,7 @@ module.exports = function (settings) {
   var cmd = "./node_modules/.bin/mocha";
   var args = [];
 
-  if ( mochaSettings.suiteTag !== undefined ) {
+  if (mochaSettings.suiteTag !== undefined) {
     reporter = path.resolve(__dirname, "suite_capture.js");
     args.push("--reporter-options", "tag=" + mochaSettings.suiteTag);
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,9 +1,17 @@
 "use strict";
 
 module.exports = {
+  mocha_args: {
+    example: "'-R reporter'",
+    description: "Append runtime command line arguments onto mocha"
+  },
   tags: {
     example: "tag1,tag2",
     description: "Run all tests that match a list of comma-delimited tags (eg: tag1,tag2)"
+  },
+  suiteTag: {
+    example: "tag",
+    description: "Run all test suites (not individual tests) that match the given tag"
   },
   group: {
     example: "prefix/path",

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  mocha_args: {
+  mochaArgs: {
     example: "'-R reporter'",
     description: "Append runtime command line arguments onto mocha"
   },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,11 +2,15 @@
 
 var settings = {
   mochaOpts: undefined, // --mocha_opts opts_file
+  mochaArgs: undefined, // --mocha_args command line arguments
   mochaTestFolders: undefined, // --mocha_tests location (or array in magellan.json)
+  suiteTag: undefined,
 
   initialize: function (argv) {
     settings.mochaOpts = argv.mocha_opts;
+    settings.mochaArgs = argv.mocha_args;
     settings.mochaTestFolders = argv.mocha_tests;
+    settings.suiteTag = argv.suiteTag;
   }
 };
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -8,7 +8,7 @@ var settings = {
 
   initialize: function (argv) {
     settings.mochaOpts = argv.mocha_opts;
-    settings.mochaArgs = argv.mocha_args;
+    settings.mochaArgs = argv.mochaArgs;
     settings.mochaTestFolders = argv.mocha_tests;
     settings.suiteTag = argv.suiteTag;
   }

--- a/lib/suite_capture.js
+++ b/lib/suite_capture.js
@@ -1,0 +1,54 @@
+/* eslint valid-jsdoc: 0 */
+"use strict";
+
+var fs = require("fs");
+
+/**
+ * Recursive function, takes a mocha test suite and returns a flattened list of
+ * tagged suites found within
+ */
+function getSuites(suite, wantedTag) {
+  var suites = [];
+
+  if ( suite.title.indexOf("@" + wantedTag) > -1 ) {
+    suites.push({
+      file: suite.file,
+      title: suite.title,
+      fullTitle: suite.fullTitle(),
+      pending: suite.pending
+    });
+  }
+
+  suite.suites.forEach(function (s) {
+    suites = suites.concat(getSuites(s, wantedTag));
+  });
+
+  return suites;
+}
+
+/**
+ * Used as a mocha repoter for the test capturing phase
+ */
+module.exports = function (runner, options) {
+  var outputPath = process.env.MOCHA_CAPTURE_PATH;
+  if (!outputPath) {
+    throw new Error("Environment variable MOCHA_CAPTURE_PATH must be defined");
+  }
+
+  // capture but do not run tests
+  runner.run = function (done) {
+    done();
+  };
+
+  // traverse suite structure and flattened list of tagged suites
+  var suites = getSuites(runner.suite, options.reporterOptions.tag);
+
+  // process .only greps
+  if (options.grep) {
+    suites = suites.filter(function (t) {
+      return t.fullTitle.match(options.grep);
+    });
+  }
+
+  fs.writeFileSync(process.env.MOCHA_CAPTURE_PATH, JSON.stringify(suites));
+};

--- a/lib/suite_capture.js
+++ b/lib/suite_capture.js
@@ -8,9 +8,10 @@ var fs = require("fs");
  * tagged suites found within
  */
 function getSuites(suite, wantedTag) {
+  var matchFoundIndex = -1;
   var suites = [];
 
-  if ( suite.title.indexOf("@" + wantedTag) > -1 ) {
+  if (suite.title.indexOf("@" + wantedTag) > matchFoundIndex) {
     suites.push({
       file: suite.file,
       title: suite.title,

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -118,6 +118,10 @@ RowdyMochaTestRun.prototype.getArguments = function () {
     args.push("--opts", mochaSettings.mochaOpts);
   }
 
+  if (mochaSettings.mochaArgs !== undefined) {
+    args = args.concat(mochaSettings.mochaArgs.split(' '));
+  }
+
   args = args.concat(mochaSettings.mochaTestFolders);
 
   return args;

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -43,7 +43,7 @@ MochaTestRun.prototype.getArguments = function () {
   }
 
   if (mochaSettings.mochaArgs !== undefined) {
-    args = args.concat(mochaSettings.mochaArgs.split(' '));
+    args = args.concat(mochaSettings.mochaArgs.split(" "));
   }
 
   args = args.concat(mochaSettings.mochaTestFolders);

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -119,7 +119,7 @@ RowdyMochaTestRun.prototype.getArguments = function () {
   }
 
   if (mochaSettings.mochaArgs !== undefined) {
-    args = args.concat(mochaSettings.mochaArgs.split(' '));
+    args = args.concat(mochaSettings.mochaArgs.split(" "));
   }
 
   args = args.concat(mochaSettings.mochaTestFolders);

--- a/test/get_suites.spec.js
+++ b/test/get_suites.spec.js
@@ -1,0 +1,41 @@
+/* eslint no-undef: 0, no-unused-expressions: 0, filenames/filenames: 0,
+  no-magic-numbers: 0, camelcase: 0 */
+"use strict";
+
+var path = require("path");
+var chai = require("chai");
+var expect = chai.expect;
+var Locator = require("../lib/locator");
+var testFramework = require("../index");
+
+function getTestsFrom(specs) {
+  if (!Array.isArray(specs)) { specs = [specs]; }
+  testFramework.initialize({
+    mocha_tests: specs,
+    mocha_opts: path.join(specs[0], "mocha.opts"),
+    suiteTag: "suite"
+  });
+  return testFramework.iterator({tempDir: path.resolve(".")});
+}
+
+describe("suite iterator", function () {
+  var suites;
+
+  before(function () {
+    suites = getTestsFrom("./test_support/suite");
+  });
+
+  it("finds suites", function () {
+    expect(suites).to.have.length(2);
+  });
+
+  it("instantiates tests as Locators", function () {
+    expect(suites[0]).to.be.an.instanceOf(Locator);
+  });
+
+  it("collects details of a test", function () {
+    var suite = suites[0];
+    expect(suite.name).to.equal("Suite @suite");
+    expect(suites[0].filename).to.contain("test_support/suite/spec.js");
+  });
+});

--- a/test_support/suite/spec.js
+++ b/test_support/suite/spec.js
@@ -1,0 +1,11 @@
+describe('Suite @suite', function() {
+	it('passes', function() {});
+	it('passes', function() {});
+	it('passes', function() {});
+});
+describe('Suite 2 @suite', function() {
+	it('passes', function() {});
+});
+describe('Suite 3 (excluded)', function() {
+	it('passes', function() {});
+});


### PR DESCRIPTION
I realize it's an anti-pattern with mocha, but my tests are constructed with dependencies in between `it()`blocks in a suite.  This PR adds a capability to the Magellan mocha plugin to make specifically-tagged _suites_ as the main unit of testing, rather than the individual tests themselves.

Usage: `magellan --suiteTag=parallel` will run every `describe()` block that's tagged with `@parallel`

I've also added a feature to add runtime arguments to mocha (as opposed to limiting them to the `mocha.opts` file).  The use case for this is that I have arguments (a specific reporter) that I want included every time Magellan runs, but not when I'm running mocha manually.

Usage: `magellan --mocha_args="-R reporter"`

I'd love some feedback on my approach, and whether it's something that can be incorporated when the mocha plugin supports Magellan 10.0 or if I'll need a different approach.

Thanks!