### PR TITLE
Add TEMP_ASSET_PATH env var

### DIFF
--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -10,6 +10,9 @@ var _ = require("lodash");
 var mochaSettings = require("./settings");
 
 var MochaTestRun = function (options) {
+  // Share assets directory with mocha tests
+  process.env.TEMP_ASSET_PATH = options.tempAssetPath;
+  
   _.extend(this, options);
 };
 

--- a/lib/test_run.js
+++ b/lib/test_run.js
@@ -12,7 +12,6 @@ var mochaSettings = require("./settings");
 var MochaTestRun = function (options) {
   // Share assets directory with mocha tests
   process.env.TEMP_ASSET_PATH = options.tempAssetPath;
-  
   _.extend(this, options);
 };
 


### PR DESCRIPTION
Sometimes it is required to access magellan temp dirs within tests (e.g. to manipulate with reports/screenshots)